### PR TITLE
Remove unnecessary bs4 import

### DIFF
--- a/src/bootstrap4/renderers.py
+++ b/src/bootstrap4/renderers.py
@@ -1,4 +1,3 @@
-from bs4 import BeautifulSoup
 from django.forms import (
     CheckboxInput,
     CheckboxSelectMultiple,


### PR DESCRIPTION
This snuck in with https://github.com/zostera/django-bootstrap4/commit/aabd551aefc6c2dbd56dac4c5030d175c1120f96 but doesn't appear to be used at all (and prevents installing the current master for some reason)